### PR TITLE
client side package.json file syntax fix

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -67,7 +67,7 @@
     "@storybook/addon-links": "^6.3.8",
     "@storybook/node-logger": "^6.3.8",
     "@storybook/preset-create-react-app": "^3.2.0",
-    "@storybook/react": "^6.3.8"
-    "@mdx-js/mdx": "^1.6.22",
+    "@storybook/react": "^6.3.8",
+    "@mdx-js/mdx": "^1.6.22"
   }
 }


### PR DESCRIPTION
Found a syntax error in the package.json file of the client folder ... it was an extra coma that would crash the app if not deleted.