### PR TITLE
Tasks 14 & 15: add templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,24 @@
+---
+name: Bug Report
+about: Use this template for reporting bugs
+labels: ["bug"]
+---
+
+# Expected Behavior
+
+<!-- Write out what the site or code should be doing here. -->
+
+# Actual Behavior
+
+<!-- Write out what the site or code is doing here that is not expected. -->
+
+# Steps to Reproduce the Problem
+
+1. 
+1. 
+1. 
+
+# Additional Info
+
+<!-- Optional. If there's any additional information that you have, mention it here. -->
+<!-- You can attach screenshots too by pasting them in the window. -->

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,14 @@
+---
+name: Feature Request
+about: Use this template for requesting new features
+label: ["feature-request"]
+---
+
+# Summary
+<!-- What is the feature? Is there a user story that this feature addresses? -->
+
+# Additional notes
+<!-- (Optional)
+- suggest assignees
+- suggest libraries, plan of action, etc.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- Hello! Thank you for contributing! -->
 
-<!-- Please do NOT modify the headers (the ## lines). Just add or change the content in between them. -->
+<!-- Please add to the template by writing in place of the comments. -->
 
 ## Type of change
 
@@ -10,16 +10,15 @@
 ## Description
 <!--
 If there's a linked issue, feel free to leave this blank. Otherwise, please let us know:
-
 - if your PR has a dependency with another PR
 - if merged, what changes would be required to the README instructions (if any)
 - any other information that could be helpful
 -->
+
 ## Questions and concerns 
+
 <!-- (Optional)
-
 If applicable, please include:
-
 - any files and line numbers
 - suggestions for a new issue (e.g. if a problem is coming from outside the scope of your ticket's files)
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!-- Hello! Thank you for contributing! -->
+
+<!-- Please do NOT modify the headers (the ## lines). Just add or change the content in between them. -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue) 
+- [ ] New feature (non-breaking change which adds functionality)
+
+## Description
+<!--
+If there's a linked issue, feel free to leave this blank. Otherwise, please let us know:
+
+- if your PR has a dependency with another PR
+- if merged, what changes would be required to the README instructions (if any)
+- any other information that could be helpful
+-->
+## Questions and concerns 
+<!-- (Optional)
+
+If applicable, please include:
+
+- any files and line numbers
+- suggestions for a new issue (e.g. if a problem is coming from outside the scope of your ticket's files)
+-->


### PR DESCRIPTION
- combining tasks 14 and 15 (issues and pull request templates)
- we may need to revisit the option to create issues without a template (set `blank_issues_enabled` to `false` in `course-tracker/.github/ISSUE_TEMPLATE/config.yml`)
