### PR TITLE
Task-86-create-logout-route

### DIFF
--- a/packages/client/src/App.js
+++ b/packages/client/src/App.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import React from "react";
-import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
+import { BrowserRouter as Router, Switch } from "react-router-dom";
 import { AuthContextProvider } from "./context/AuthContext";
 import Login from "./components/Login";
 import Feed from "./Feed";

--- a/packages/client/src/context/AuthContext.js
+++ b/packages/client/src/context/AuthContext.js
@@ -23,6 +23,8 @@ export const AuthContextProvider = ({ children }) => {
   }, []);
 
   const logout = useCallback(() => {
+    const user = JSON.parse(localStorage.getItem("Token Object"));
+    axios.post(`${backend}api/auth/logout/${user.userId}`);
     _dispatch({});
     localStorage.removeItem("Token Object");
     window.location.reload(false);

--- a/packages/server/controllers/auth.js
+++ b/packages/server/controllers/auth.js
@@ -38,6 +38,12 @@ module.exports = {
     }
     res.status(401).json({ message: "Invalid credentials" });
   },
+  logout: async (req) => {
+    await User.findByIdAndUpdate(
+      { _id: req.params.userId },
+      { refreshtoken: "" }
+    );
+  },
   createUser: async (req, res) => {
     const { username, email, password } = req.body;
 

--- a/packages/server/routes/authRoutes.js
+++ b/packages/server/routes/authRoutes.js
@@ -11,6 +11,7 @@ router.put(
   checkAdmin,
   authController.updatePassword
 );
+router.post("/logout/:userId", authController.logout);
 
 if (process.env.NODE_ENV !== "production") {
   router.get("/get-user/:id", authController.getUser);


### PR DESCRIPTION
<!-- Hello! Thank you for contributing! -->

<!-- Please add to the template by writing in place of the comments. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue) 
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--
If there's a linked issue, feel free to leave this blank. Otherwise, please let us know:
- if your PR has a dependency with another PR
- if merged, what changes would be required to the README instructions (if any)
- any other information that could be helpful
-->
Creates log-out endpoint in API which clears the refresh token from the mongo user document.

## Questions and concerns 

<!-- (Optional)
If applicable, please include:
- any files and line numbers
- suggestions for a new issue (e.g. if a problem is coming from outside the scope of your ticket's files)
-->
