### PR TITLE
Fixing-merge-mistake: deleted extra footers

### DIFF
--- a/packages/client/src/Feed.js
+++ b/packages/client/src/Feed.js
@@ -24,7 +24,7 @@ const Feed = () => {
 
   useEffect(() => {
     populateFeed();
-  }, [editSubmitted]);
+  }, [editSubmitted, user.userId]);
 
   if (loading) {
     return <></>;

--- a/packages/client/src/Feed.js
+++ b/packages/client/src/Feed.js
@@ -47,7 +47,6 @@ const Feed = () => {
           );
         })}
       </FeedDiv>
-      <Footer/>
     </>
   );
 };

--- a/packages/client/src/components/CreatePost.js
+++ b/packages/client/src/components/CreatePost.js
@@ -14,7 +14,7 @@ import { AuthContext } from "../context/AuthContext";
 import axios from "axios";
 
 function CreatePost() {
-  const { user, isAdmin, getAdminStatus} = useContext(AuthContext);
+  const { user, getAdminStatus} = useContext(AuthContext);
   const history = useHistory();
 
   const [post, setPost] = useState({
@@ -40,7 +40,7 @@ function CreatePost() {
 
   useEffect(() => {
     getAdminStatus(user.userId);
-  }, []);
+  }, [getAdminStatus, user.userId]);
 
   return (
     <>

--- a/packages/client/src/components/CreatePost.js
+++ b/packages/client/src/components/CreatePost.js
@@ -94,7 +94,6 @@ function CreatePost() {
           </ButtonDiv>
         </Form>
       </Container>
-      <Footer/>
     </>
   );
 }

--- a/packages/client/src/components/Layout.js
+++ b/packages/client/src/components/Layout.js
@@ -1,13 +1,10 @@
-import { useContext } from "react";
 import { useLocation } from "react-router-dom";
 import Navbar from "./Navbar";
 import Footer from "./Footer";
-// import { AuthContext } from "../context/AuthContext";
 
 const excludeNav = ["/login"];
 
 function Layout({ children }) {
-  // const { isAdmin } = useContext(AuthContext);
   const { pathname } = useLocation();
   if (excludeNav.includes(pathname)) {
     return (

--- a/packages/client/src/components/Layout.js
+++ b/packages/client/src/components/Layout.js
@@ -2,26 +2,26 @@ import { useContext } from "react";
 import { useLocation } from "react-router-dom";
 import Navbar from "./Navbar";
 import Footer from "./Footer";
-import { AuthContext } from "../context/AuthContext";
+// import { AuthContext } from "../context/AuthContext";
 
 const excludeNav = ["/login"];
 
 function Layout({ children }) {
-  const { isAdmin } = useContext(AuthContext);
+  // const { isAdmin } = useContext(AuthContext);
   const { pathname } = useLocation();
   if (excludeNav.includes(pathname)) {
     return (
       <>
         {children}
-        <Footer isAdmin={isAdmin} />
+        <Footer/>
       </>
     );
   }
   return (
     <>
-      <Navbar isAdmin={isAdmin} />
+      <Navbar/>
       {children}
-      <Footer isAdmin={isAdmin} />
+      <Footer/>
     </>
   );
 }

--- a/packages/client/src/components/Navbar.js
+++ b/packages/client/src/components/Navbar.js
@@ -6,10 +6,13 @@ import TextLink from "./TextLink";
 import { AuthContext } from "../context/AuthContext";
 
 const Navbar = (props) => {
-  const { logout } = useContext(AuthContext);
+  const { logout, isAdmin } = useContext(AuthContext);
   const [sidebar, setSidebar] = useState(false);
   const showSidebar = () => setSidebar(!sidebar);
-
+  const logoutFunc = () => {
+      logout();
+      setSidebar(!sidebar);
+  }
   const NavButton = () => {
     return (
       <PlusCircle
@@ -40,15 +43,16 @@ const Navbar = (props) => {
         <NavContainer clicked={sidebar}>
           <ul>
             <ListItem>
-              <TextLink text="Home" link="/" align="left" />
+              <TextLink text="Home" link="/" align="left" onClick={() => showSidebar()}/>
             </ListItem>
-            {props.isAdmin && (
+            {isAdmin && (
               <>
                 <ListItem>
                   <TextLink
                     text="Create a Post"
                     link="/create-post"
                     align="left"
+                    onClick={() => showSidebar()}
                   />
                 </ListItem>
                 <ListItem>
@@ -56,7 +60,7 @@ const Navbar = (props) => {
                     text="Logout"
                     link="/"
                     align="left"
-                    onClick={() => logout()}
+                    onClick={() => logoutFunc()}
                   />
                 </ListItem>
               </>


### PR DESCRIPTION
<!-- Hello! Thank you for contributing! -->

<!-- Please add to the template by writing in place of the comments. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) 
- [x] New feature (non-breaking change which adds functionality)

## Description
<!--
If there's a linked issue, feel free to leave this blank. Otherwise, please let us know:
- if your PR has a dependency with another PR
- if merged, what changes would be required to the README instructions (if any)
- any other information that could be helpful
-->
Deleted the extra footers in Feed and CreatePost. Having not realized they were abstracted to the Layout component I merged my versions of the Feed and CreatePost into main.

I also then abstracted the is admin prop in the Navbar and added the functionality that closes the navbar once the Home, Create a post or Log out links are clicked.

I also added a dependency on the useEffect of the Feed so that it re-renders on log-out.

## Questions and concerns 

<!-- (Optional)
If applicable, please include:
- any files and line numbers
- suggestions for a new issue (e.g. if a problem is coming from outside the scope of your ticket's files)
-->
