### PR TITLE
Fixes bug where isEdit State persists thru logout.

### DIFF
--- a/packages/client/src/Feed.js
+++ b/packages/client/src/Feed.js
@@ -8,9 +8,10 @@ const backend = process.env.REACT_APP_BACKEND;
 
 const Feed = () => {
   const { user, isAdmin, getAdminStatus } = useContext(AuthContext);
+  const [isEdit, setIsEdit] = useState({})
   const [loading, setLoading] = useState(true);
   const [posts, setPosts] = useState();
-  const [editSubmitted, setEditSubmitted] = useState(false);
+  const [isNewUpdates, setIsNewUpdates] = useState(false);
 
   const populateFeed = async () => {
     const adminCheck = await getAdminStatus(user.userId);
@@ -19,11 +20,16 @@ const Feed = () => {
     );
     setPosts(res.data.posts);
     setLoading(false);
+    const isEditMap = {}
+    for(const post of res.data.posts){
+      isEditMap[post._id] = false
+    }
+    setIsEdit(isEditMap)
   };
 
   useEffect(() => {
     populateFeed();
-  }, [editSubmitted, user.userId]);
+  }, [isNewUpdates, user.userId]);
 
   return (
     <>
@@ -39,7 +45,9 @@ const Feed = () => {
                 id={post._id}
                 key={post._id}
                 user={user}
-                setEditSubmitted={setEditSubmitted}
+                setIsNewUpdates={setIsNewUpdates}
+                isEdit={isEdit}
+                setIsEdit={setIsEdit}
               />
             );
           })}

--- a/packages/client/src/components/Post.js
+++ b/packages/client/src/components/Post.js
@@ -17,10 +17,11 @@ const Post = ({
   isAdmin,
   id,
   user,
-  setEditSubmitted,
+  setIsNewUpdates,
+  isEdit,
+  setIsEdit
 }) => {
   const [hiddenState, setHiddenState] = useState(true);
-  const [isEdit, setIsEdit] = useState(false);
   const [post, updatePost] = useState({
     title,
     body,
@@ -39,14 +40,16 @@ const Post = ({
 
   const sendChangeObj = async (e) => {
     e.preventDefault();
-    setIsEdit((prevState) => !prevState);
+    setIsEdit((prevState) => {
+      return {...prevState, id: false}
+    });
     await axios.put(
       `api/post/edit-post/${id}`,
       { ...changeObj, isDraft: e.target.value },
       { headers: { Authentication: user.accesstoken } }
     );
     setChangeObj({});
-    setEditSubmitted((prev) => !prev);
+    setIsNewUpdates((prev) => !prev);
   };
 
   const deletePost = async (e) => {
@@ -54,7 +57,7 @@ const Post = ({
     await axios.delete(`api/post/delete-post/${id}`, {
       headers: { Authentication: user.accesstoken },
     });
-    setEditSubmitted((prev) => !prev);
+    setIsNewUpdates((prev) => !prev);
   };
 
   const handleCollapse = () => {
@@ -63,7 +66,7 @@ const Post = ({
 
   const cancel = async () => {
     setChangeObj({});
-    setEditSubmitted((prev) => !prev);
+    setIsNewUpdates((prev) => !prev);
     updatePost({
       title,
       body,
@@ -71,14 +74,15 @@ const Post = ({
       isAdmin,
       id,
       user,
-      setEditSubmitted,
+      setIsNewUpdates,
     });
-    setIsEdit((prevState) => !prevState);
+    setIsEdit((prevState) => {
+      return {...prevState, [id]: false}
+    });
   };
-
   return (
     <Container padding="1.5rem 1.5rem 0 1.5rem">
-      {isEdit ? (
+      {isEdit[id] ? (
         <EditingForm
           isDraft={isDraft}
           cancel={cancel}
@@ -89,7 +93,7 @@ const Post = ({
         />
       ) : (
         <PostDiv>
-          <PostHeader onClick={() => !isEdit && handleCollapse()} edit={isEdit}>
+          <PostHeader onClick={() => !isEdit[id] && handleCollapse()} edit={isEdit[id]}>
             <h2>{title}</h2>
             {isAdmin &&
               (isDraft ? (
@@ -98,13 +102,15 @@ const Post = ({
                 <Eye aria-label="" className="published" />
               ))}
           </PostHeader>
-          <CollapsibleDiv hidden={hiddenState} edit={isEdit}>
+          <CollapsibleDiv hidden={hiddenState} edit={isEdit[id]}>
             <MarkdownParser markdown={body} />
             {isAdmin && (
               <ButtonDiv justify="flex-end">
                 <Button onClick={(e) => deletePost(e)}>Delete</Button>
                 <Button
-                  onClick={() => setIsEdit((prevState) => !prevState)}
+                  onClick={() =>  setIsEdit((prevState) => {
+                    return {...prevState, [id]: true}
+                  })}
                   margin="0 0 0 1.5rem"
                 >
                   Edit


### PR DESCRIPTION
Co-authored-by: Arielle Morabito <relspeedwagon@users.noreply.github.com>
Co-authored-by: 3dvkr <3dvkr@users.noreply.github.com>

<!-- Hello! Thank you for contributing! -->

<!-- Please add to the template by writing in place of the comments. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) 

## Description
<!--
If there's a linked issue, feel free to leave this blank. Otherwise, please let us know:
- if your PR has a dependency with another PR
- if merged, what changes would be required to the README instructions (if any)
- any other information that could be helpful
-->

If we're logged in as admin, and we open the editing form on a post, and we log out while that form is open, the app shows the editing form while logged out.

The Post component handled the isEdit state which controls whether or not you can see the form. The isAdmin check happens in its parent component, Feed. 

We lifted the isEdit control for each post to the Feed instead of doing the isAdmin check repeatedly for each Post component.

## Questions and concerns 

<!-- (Optional)
If applicable, please include:
- any files and line numbers
- suggestions for a new issue (e.g. if a problem is coming from outside the scope of your ticket's files)
-->
